### PR TITLE
chore: systemd: make targets able to be enabled at boot

### DIFF
--- a/mta/carbonio-mta.target
+++ b/mta/carbonio-mta.target
@@ -5,3 +5,6 @@ Requires=multi-user.target
 After=multi-user.target
 PartOf=carbonio-ce.target carbonio.target
 AllowIsolate=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is a QA-fix and should be back-merged in devel.
After the merge in main a new tag and version should be forged