### PR TITLE
chore: define mta container for development

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,12 @@
+def buildContainer(String title, String description, String dockerfile, String tag) {
+    sh 'docker build ' +
+            '--label org.opencontainers.image.title="' + title + '" ' +
+            '--label org.opencontainers.image.description="' + description + '" ' +
+            '--label org.opencontainers.image.vendor="Zextras" ' +
+            '-f ' + dockerfile + ' -t ' + tag + ' .'
+    sh 'docker push ' + tag
+}
+
 pipeline {
     parameters {
         booleanParam defaultValue: false,
@@ -26,6 +35,19 @@ pipeline {
                     env.GIT_COMMIT = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
                 }
                 stash includes: '**', name: 'staging'
+            }
+        }
+        stage('Publish containers - devel') {
+            when {
+                branch 'devel';
+            }
+            steps {
+                container('dind') {
+                    withDockerRegistry(credentialsId: 'private-registry', url: 'https://registry.dev.zextras.com') {
+                        buildContainer('Carbonio MTA', '$(cat docker/mta/description.md)',
+                                'docker/mta/Dockerfile', 'registry.dev.zextras.com/dev/carbonio-mta:latest')
+                    }
+                }
             }
         }
 

--- a/docker/mta/Dockerfile
+++ b/docker/mta/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:jammy
+
+USER root
+
+ENV LDAP_ROOT_PASSWORD=qh6hWZvc
+ENV LDAP_HOST=openldap
+ENV LDAP_PORT=1389
+
+RUN apt update && apt install -y gnupg2 ca-certificates && apt clean && \
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A21 && \
+echo deb https://repo.zextras.io/release/ubuntu jammy main > /etc/apt/sources.list.d/zextras.list && \
+apt update && apt install -y carbonio-postfix telnet netcat && apt clean
+
+COPY docker/mta/conf/ /opt/zextras/conf/
+COPY docker/mta/postfix_header_checks /opt/zextras/conf/postfix_header_checks
+COPY docker/mta/entrypoint.sh .
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker/mta/Dockerfile
+++ b/docker/mta/Dockerfile
@@ -5,6 +5,7 @@ USER root
 ENV LDAP_ROOT_PASSWORD=qh6hWZvc
 ENV LDAP_HOST=openldap
 ENV LDAP_PORT=1389
+EXPOSE 25
 
 RUN apt update && apt install -y gnupg2 ca-certificates && apt clean && \
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A21 && \

--- a/docker/mta/conf/ldap-canonical.cf
+++ b/docker/mta/conf/ldap-canonical.cf
@@ -1,0 +1,12 @@
+server_host = ldap://LDAP_HOST:LDAP_PORT
+server_port = 1389
+search_base =
+query_filter = (&(|(zimbraMailDeliveryAddress=%s)(zimbraMailAlias=%s)(zimbraMailCatchAllAddress=%s))(zimbraMailStatus=enabled))
+result_attribute = zimbraMailCanonicalAddress,zimbraMailCatchAllCanonicalAddress
+version = 3
+start_tls = no
+tls_ca_cert_dir = /opt/zextras/conf/ca
+bind = yes
+bind_dn = uid=zmpostfix,cn=appaccts,cn=zimbra
+bind_pw = LDAP_ROOT_PASSWORD
+timeout = 30

--- a/docker/mta/conf/ldap-transport.cf
+++ b/docker/mta/conf/ldap-transport.cf
@@ -1,0 +1,12 @@
+server_host = ldap://LDAP_HOST:LDAP_PORT
+server_port = 1389
+search_base =
+query_filter = (&(|(zimbraMailDeliveryAddress=%s)(zimbraDomainName=%s))(zimbraMailStatus=enabled))
+result_attribute = zimbraMailTransport
+version = 3
+start_tls = no
+tls_ca_cert_dir = /opt/zextras/conf/ca
+bind = yes
+bind_dn = uid=zmpostfix,cn=appaccts,cn=zimbra
+bind_pw = LDAP_ROOT_PASSWORD
+timeout = 30

--- a/docker/mta/conf/ldap-vad.cf
+++ b/docker/mta/conf/ldap-vad.cf
@@ -1,0 +1,12 @@
+server_host = ldap://LDAP_HOST:LDAP_PORT
+server_port = 1389
+search_base =
+query_filter = (&(zimbraDomainName=%s)(zimbraDomainType=alias)(zimbraMailStatus=enabled))
+result_attribute = zimbraDomainName
+version = 3
+start_tls = no
+tls_ca_cert_dir = /opt/zextras/conf/ca
+bind = yes
+bind_dn = uid=zmpostfix,cn=appaccts,cn=zimbra
+bind_pw = LDAP_ROOT_PASSWORD
+timeout = 30

--- a/docker/mta/conf/ldap-vam.cf
+++ b/docker/mta/conf/ldap-vam.cf
@@ -1,0 +1,13 @@
+server_host = ldap://LDAP_HOST:LDAP_PORT
+server_port = 1389
+search_base =
+query_filter = (&(|(zimbraMailDeliveryAddress=%s)(zimbraMailAlias=%s)(zimbraOldMailAddress=%s)(zimbraMailCatchAllAddress=%s))(zimbraMailStatus=enabled))
+result_attribute = zimbraMailDeliveryAddress,zimbraMailForwardingAddress,zimbraPrefMailForwardingAddress,zimbraMailCatchAllForwardingAddress
+version = 3
+start_tls = no
+tls_ca_cert_dir = /opt/zextras/conf/ca
+bind = yes
+bind_dn = uid=zmpostfix,cn=appaccts,cn=zimbra
+bind_pw = LDAP_ROOT_PASSWORD
+timeout = 30
+special_result_attribute = member

--- a/docker/mta/conf/ldap-vmd.cf
+++ b/docker/mta/conf/ldap-vmd.cf
@@ -1,0 +1,12 @@
+server_host = ldap://LDAP_HOST:LDAP_PORT
+server_port = 1389
+search_base =
+query_filter = (&(zimbraDomainName=%s)(zimbraDomainType=local)(zimbraMailStatus=enabled))
+result_attribute = zimbraDomainName
+version = 3
+start_tls = no
+tls_ca_cert_dir = /opt/zextras/conf/ca
+bind = yes
+bind_dn = uid=zmpostfix,cn=appaccts,cn=zimbra
+bind_pw = LDAP_ROOT_PASSWORD
+timeout = 30

--- a/docker/mta/conf/ldap-vmm.cf
+++ b/docker/mta/conf/ldap-vmm.cf
@@ -1,0 +1,12 @@
+server_host = ldap://LDAP_HOST:LDAP_PORT
+server_port = 1389
+search_base =
+query_filter = (&(zimbraMailDeliveryAddress=%s)(zimbraMailStatus=enabled))
+result_attribute = zimbraMailDeliveryAddress
+version = 3
+start_tls = no
+tls_ca_cert_dir = /opt/zextras/conf/ca
+bind = yes
+bind_dn = uid=zmpostfix,cn=appaccts,cn=zimbra
+bind_pw = LDAP_ROOT_PASSWORD
+timeout = 30

--- a/docker/mta/description.md
+++ b/docker/mta/description.md
@@ -1,0 +1,2 @@
+This image provides a working Carbonio MTA server with a minimal Postfix 
+configuration to allows sending and receiving emails within the infrastructure.

--- a/docker/mta/entrypoint.sh
+++ b/docker/mta/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+
+sed -i -e "s/LDAP_HOST/${LDAP_HOST}/g" /opt/zextras/conf/*.cf
+sed -i -e "s/LDAP_PORT/${LDAP_PORT}/g" /opt/zextras/conf/*.cf
+sed -i -e "s/LDAP_ROOT_PASSWORD/${LDAP_ROOT_PASSWORD}/g" /opt/zextras/conf/*.cf
+sed -i -e "s#LDAP_URL#${LDAP_URL}#g" /opt/zextras/conf/*.cf
+
+/opt/zextras/common/sbin/postconf maillog_file=/var/log/postfix.log
+
+/opt/zextras/common/sbin/postfix start
+
+tail -f /var/log/postfix.log

--- a/docker/mta/postfix_header_checks
+++ b/docker/mta/postfix_header_checks
@@ -1,0 +1,4 @@
+#/filename=\"?(.*)\.()\"?$/
+#	REJECT For security reasons we reject attachments of this type
+#/^\s*Content-(Disposition|Type).*name\s*=\s*"?(.+\.())"?\s*$/
+#	REJECT Attachment type not allowed. File "$2" has the unacceptable extension "$3"


### PR DESCRIPTION
Moved definition from mailbox codebase.
With time we can start using the real postfix configurations defined in this repo.

Requires: https://github.com/zextras/carbonio-mta/pull/28 for CI
