### PR TITLE
ci: move to kube agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     }
     agent {
         node {
-            label 'base-agent-v2'
+            label 'base'
         }
     }
     environment {
@@ -34,7 +34,7 @@ pipeline {
                         stage('Ubuntu 20') {
                             agent {
                                 node {
-                                    label 'yap-agent-ubuntu-20.04-v2'
+                                    label 'yap-ubuntu-20-v1'
                                 }
                             }
                             steps {
@@ -58,7 +58,7 @@ pipeline {
                         stage('Ubuntu 22') {
                             agent {
                                 node {
-                                    label 'yap-agent-ubuntu-22.04-v2'
+                                    label 'yap-ubuntu-22-v1'
                                 }
                             }
                             steps {
@@ -82,7 +82,7 @@ pipeline {
                         stage('Ubuntu 24') {
                             agent {
                                 node {
-                                    label 'yap-agent-ubuntu-24.04-v2'
+                                    label 'yap-ubuntu-24-v1'
                                 }
                             }
                             steps {
@@ -107,7 +107,7 @@ pipeline {
                         stage('RHEL8') {
                             agent {
                                 node {
-                                    label 'yap-agent-rocky-8-v2'
+                                    label 'yap-rocky-8-v1'
                                 }
                             }
                             steps {
@@ -120,11 +120,11 @@ pipeline {
                                         sh 'yap build rocky-8 . -s'
                                     }
                                 }
-                                stash includes: 'artifacts/x86_64/*el8*.rpm', name: 'artifacts-rhel8'
+                                stash includes: 'artifacts/*el8*.rpm', name: 'artifacts-rhel8'
                             }
                             post {
                                 always {
-                                    archiveArtifacts artifacts: "artifacts/x86_64/*el8*.rpm", fingerprint: true
+                                    archiveArtifacts artifacts: "artifacts/*el8*.rpm", fingerprint: true
                                 }
                             }
                         }
@@ -132,7 +132,7 @@ pipeline {
                         stage('RHEL9') {
                             agent {
                                 node {
-                                    label 'yap-agent-rocky-9-v2'
+                                    label 'yap-rocky-9-v1'
                                 }
                             }
                             steps {
@@ -145,11 +145,11 @@ pipeline {
                                         sh 'yap build rocky-9 . -s'
                                     }
                                 }
-                                stash includes: 'artifacts/x86_64/*el9*.rpm', name: 'artifacts-rhel9'
+                                stash includes: 'artifacts/*el9*.rpm', name: 'artifacts-rhel9'
                             }
                             post {
                                 always {
-                                    archiveArtifacts artifacts: "artifacts/x86_64/*el9*.rpm", fingerprint: true
+                                    archiveArtifacts artifacts: "artifacts/*el9*.rpm", fingerprint: true
                                 }
                             }
                         }
@@ -194,12 +194,12 @@ pipeline {
                                 "props": "deb.distribution=noble;deb.component=main;deb.architecture=amd64;vcs.revision=${env.GIT_COMMIT}"
                             },
                             {
-                                "pattern": "artifacts/x86_64/(carbonio-mta)-(*).el8.x86_64.rpm",
+                                "pattern": "artifacts/(carbonio-mta)-(*).el8.x86_64.rpm",
                                 "target": "centos8-playground/zextras/{1}/{1}-{2}.el8.x86_64.rpm",
                                 "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
                             },
                             {
-                                "pattern": "artifacts/x86_64/(carbonio-mta)-(*).el9.x86_64.rpm",
+                                "pattern": "artifacts/(carbonio-mta)-(*).el9.x86_64.rpm",
                                 "target": "rhel9-playground/zextras/{1}/{1}-{2}.el9.x86_64.rpm",
                                 "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
                             }
@@ -244,12 +244,12 @@ pipeline {
                                 "props": "deb.distribution=noble;deb.component=main;deb.architecture=amd64;vcs.revision=${env.GIT_COMMIT}"
                             },
                             {
-                                "pattern": "artifacts/x86_64/(carbonio-mta)-(*).el8.x86_64.rpm",
+                                "pattern": "artifacts/(carbonio-mta)-(*).el8.x86_64.rpm",
                                 "target": "centos8-devel/zextras/{1}/{1}-{2}.el8.x86_64.rpm",
                                 "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
                             },
                             {
-                                "pattern": "artifacts/x86_64/(carbonio-mta)-(*).el9.x86_64.rpm",
+                                "pattern": "artifacts/(carbonio-mta)-(*).el9.x86_64.rpm",
                                 "target": "rhel9-devel/zextras/{1}/{1}-{2}.el9.x86_64.rpm",
                                 "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
                             }
@@ -319,7 +319,7 @@ pipeline {
                     uploadSpec= """{
                         "files": [
                             {
-                                "pattern": "artifacts/x86_64/(carbonio-mta)-(*).el8.x86_64.rpm",
+                                "pattern": "artifacts/(carbonio-mta)-(*).el8.x86_64.rpm",
                                 "target": "centos8-rc/zextras/{1}/{1}-{2}.el8.x86_64.rpm",
                                 "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,12 +39,14 @@ pipeline {
                             }
                             steps {
                                 unstash 'staging'
-                                script {
-                                    if (BRANCH_NAME == 'devel') {
-                                        def timestamp = new Date().format('yyyyMMddHHmmss')
-                                        sh "yap build ubuntu-focal . -r ${timestamp} -s"
-                                    } else {
-                                        sh 'yap build ubuntu-focal . -s'
+                                container('yap') {
+                                    script {
+                                        if (BRANCH_NAME == 'devel') {
+                                            def timestamp = new Date().format('yyyyMMddHHmmss')
+                                            sh "yap build ubuntu-focal . -r ${timestamp} -s"
+                                        } else {
+                                            sh 'yap build ubuntu-focal . -s'
+                                        }
                                     }
                                 }
                                 stash includes: 'artifacts/*focal*.deb', name: 'artifacts-ubuntu-focal'
@@ -63,12 +65,14 @@ pipeline {
                             }
                             steps {
                                 unstash 'staging'
-                                script {
-                                    if (BRANCH_NAME == 'devel') {
-                                        def timestamp = new Date().format('yyyyMMddHHmmss')
-                                        sh "yap build ubuntu-jammy . -r ${timestamp} -s"
-                                    } else {
-                                        sh 'yap build ubuntu-jammy . -s'
+                                container('yap') {
+                                    script {
+                                        if (BRANCH_NAME == 'devel') {
+                                            def timestamp = new Date().format('yyyyMMddHHmmss')
+                                            sh "yap build ubuntu-jammy . -r ${timestamp} -s"
+                                        } else {
+                                            sh 'yap build ubuntu-jammy . -s'
+                                        }
                                     }
                                 }
                                 stash includes: 'artifacts/*jammy*.deb', name: 'artifacts-ubuntu-jammy'
@@ -87,12 +91,14 @@ pipeline {
                             }
                             steps {
                                 unstash 'staging'
-                                script {
-                                    if (BRANCH_NAME == 'devel') {
-                                        def timestamp = new Date().format('yyyyMMddHHmmss')
-                                        sh "yap build ubuntu-noble . -r ${timestamp} -s"
-                                    } else {
-                                        sh 'yap build ubuntu-noble . -s'
+                                container('yap') {
+                                    script {
+                                        if (BRANCH_NAME == 'devel') {
+                                            def timestamp = new Date().format('yyyyMMddHHmmss')
+                                            sh "yap build ubuntu-noble . -r ${timestamp} -s"
+                                        } else {
+                                            sh 'yap build ubuntu-noble . -s'
+                                        }
                                     }
                                 }
                                 stash includes: 'artifacts/*noble*.deb', name: 'artifacts-ubuntu-noble'
@@ -112,12 +118,15 @@ pipeline {
                             }
                             steps {
                                 unstash 'staging'
-                                script {
-                                    if (BRANCH_NAME == 'devel') {
-                                        def timestamp = new Date().format('yyyyMMddHHmmss')
-                                        sh "yap build rocky-8 . -r ${timestamp} -s"
-                                    } else {
-                                        sh 'yap build rocky-8 . -s'
+                                container('yap') {
+                                    script {
+                                        if (BRANCH_NAME == 'devel') {
+                                            def timestamp = new Date().format('yyyyMMddHHmmss')
+                                            sh "yap build rocky-8 . -r ${timestamp} -s"
+                                        } else {
+                                            sh 'yap build rocky-8 . -s'
+                                        }
+
                                     }
                                 }
                                 stash includes: 'artifacts/*el8*.rpm', name: 'artifacts-rhel8'
@@ -137,12 +146,14 @@ pipeline {
                             }
                             steps {
                                 unstash 'staging'
-                                script {
-                                    if (BRANCH_NAME == 'devel') {
-                                        def timestamp = new Date().format('yyyyMMddHHmmss')
-                                        sh "yap build rocky-9 . -r ${timestamp} -s"
-                                    } else {
-                                        sh 'yap build rocky-9 . -s'
+                                container('yap') {
+                                    script {
+                                        if (BRANCH_NAME == 'devel') {
+                                            def timestamp = new Date().format('yyyyMMddHHmmss')
+                                            sh "yap build rocky-9 . -r ${timestamp} -s"
+                                        } else {
+                                            sh 'yap build rocky-9 . -s'
+                                        }
                                     }
                                 }
                                 stash includes: 'artifacts/*el9*.rpm', name: 'artifacts-rhel9'


### PR DESCRIPTION
- base-agent-v2 -> base
- agents become v1 (drop also "-agent-" keyword in name)
- pattern for rocky9 and 9 doesn't have x86_64 folder

I tried to apply the same changes as in here: https://github.com/zextras/carbonio-core/commit/d8cb6b0c1c06deb086c94a8d7d1242ebd28b1866#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8