### PR TITLE
chore (ci): upgrade to jenkins-packages-build-library@1.0.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-packages-build-library@chore/IN-930',
+    identifier: 'jenkins-packages-build-library@1.0.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-packages-build-library.git',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-packages-build-library@1.0.0',
+    identifier: 'jenkins-packages-build-library@1.0.1',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-packages-build-library.git',
@@ -57,11 +57,13 @@ pipeline {
                     withDockerRegistry(credentialsId: 'private-registry', url: 'https://registry.dev.zextras.com') {
                         script {
                             dockerHelper.buildImage([
-                                title: 'Carbonio MTA', 
-                                descriptionFile: 'docker/mta/description.md',
                                 dockerfile: 'docker/mta/Dockerfile', 
                                 imageName: 'registry.dev.zextras.com/dev/carbonio-mta',
-                                imageTags: 'latest'
+                                imageTags: 'latest',
+                                ocLabels: [
+                                    title: 'Carbonio MTA', 
+                                    descriptionFile: 'docker/mta/description.md',
+                                ]
                             ])
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,41 +1,53 @@
-def buildContainer(String title, String description, String dockerfile, String tag) {
-    sh 'docker build ' +
-            '--label org.opencontainers.image.title="' + title + '" ' +
-            '--label org.opencontainers.image.description="' + description + '" ' +
-            '--label org.opencontainers.image.vendor="Zextras" ' +
-            '-f ' + dockerfile + ' -t ' + tag + ' .'
-    sh 'docker push ' + tag
-}
+library(
+    identifier: 'jenkins-packages-build-library@chore/IN-930',
+    retriever: modernSCM([
+        $class: 'GitSCMSource',
+        remote: 'git@github.com:zextras/jenkins-packages-build-library.git',
+        credentialsId: 'jenkins-integration-with-github-account'
+    ])
+)
 
 pipeline {
-    parameters {
-        booleanParam defaultValue: false,
-                description: 'Whether to upload the packages in playground repositories',
-                name: 'PLAYGROUND'
-    }
-    options {
-        skipDefaultCheckout()
-        buildDiscarder(logRotator(numToKeepStr: '5'))
-        timeout(time: 3, unit: 'HOURS')
-    }
+    
     agent {
         node {
             label 'zextras-v1'
         }
     }
+
     environment {
         ARTIFACTORY_ACCESS=credentials('artifactory-jenkins-gradle-properties-splitted')
     }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '5'))
+        parallelsAlwaysFailFast()
+        skipDefaultCheckout()
+        timeout(time: 3, unit: 'HOURS')
+    }
+
+    parameters {
+        booleanParam defaultValue: false,
+            description: 'Whether to upload the packages in playground repositories',
+            name: 'PLAYGROUND'
+    }
+
+    tools {
+        jfrog 'jfrog-cli'
+    }
+
     stages {
+
         stage('Checkout') {
             steps {
                 checkout scm
                 script {
-                    env.GIT_COMMIT = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
+                    gitMetadata() 
                 }
                 stash includes: '**', name: 'staging'
             }
         }
+        
         stage('Publish containers - devel') {
             when {
                 branch 'devel';
@@ -43,362 +55,33 @@ pipeline {
             steps {
                 container('dind') {
                     withDockerRegistry(credentialsId: 'private-registry', url: 'https://registry.dev.zextras.com') {
-                        buildContainer('Carbonio MTA', '$(cat docker/mta/description.md)',
-                                'docker/mta/Dockerfile', 'registry.dev.zextras.com/dev/carbonio-mta:latest')
+                        script {
+                            dockerHelper.buildImage([
+                                title: 'Carbonio MTA', 
+                                descriptionFile: 'docker/mta/description.md',
+                                dockerfile: 'docker/mta/Dockerfile', 
+                                imageName: 'registry.dev.zextras.com/dev/carbonio-mta',
+                                imageTags: 'latest'
+                            ])
+                        }
                     }
                 }
             }
         }
 
         stage('Build deb/rpm') {
-            parallel {
-                        stage('Ubuntu 20') {
-                            agent {
-                                node {
-                                    label 'yap-ubuntu-20-v1'
-                                }
-                            }
-                            steps {
-                                unstash 'staging'
-                                container('yap') {
-                                    script {
-                                        if (BRANCH_NAME == 'devel') {
-                                            def timestamp = new Date().format('yyyyMMddHHmmss')
-                                            sh "yap build ubuntu-focal . -r ${timestamp} -s"
-                                        } else {
-                                            sh 'yap build ubuntu-focal . -s'
-                                        }
-                                    }
-                                }
-                                stash includes: 'artifacts/*focal*.deb', name: 'artifacts-ubuntu-focal'
-                            }
-                            post {
-                                always {
-                                    archiveArtifacts artifacts: "artifacts/*focal*.deb", fingerprint: true
-                                }
-                            }
-                        }
-                        stage('Ubuntu 22') {
-                            agent {
-                                node {
-                                    label 'yap-ubuntu-22-v1'
-                                }
-                            }
-                            steps {
-                                unstash 'staging'
-                                container('yap') {
-                                    script {
-                                        if (BRANCH_NAME == 'devel') {
-                                            def timestamp = new Date().format('yyyyMMddHHmmss')
-                                            sh "yap build ubuntu-jammy . -r ${timestamp} -s"
-                                        } else {
-                                            sh 'yap build ubuntu-jammy . -s'
-                                        }
-                                    }
-                                }
-                                stash includes: 'artifacts/*jammy*.deb', name: 'artifacts-ubuntu-jammy'
-                            }
-                            post {
-                                always {
-                                    archiveArtifacts artifacts: "artifacts/*jammy*.deb", fingerprint: true
-                                }
-                            }
-                        }
-                        stage('Ubuntu 24') {
-                            agent {
-                                node {
-                                    label 'yap-ubuntu-24-v1'
-                                }
-                            }
-                            steps {
-                                unstash 'staging'
-                                container('yap') {
-                                    script {
-                                        if (BRANCH_NAME == 'devel') {
-                                            def timestamp = new Date().format('yyyyMMddHHmmss')
-                                            sh "yap build ubuntu-noble . -r ${timestamp} -s"
-                                        } else {
-                                            sh 'yap build ubuntu-noble . -s'
-                                        }
-                                    }
-                                }
-                                stash includes: 'artifacts/*noble*.deb', name: 'artifacts-ubuntu-noble'
-                            }
-                            post {
-                                always {
-                                    archiveArtifacts artifacts: "artifacts/*noble*.deb", fingerprint: true
-                                }
-                            }
-                        }
-
-                        stage('RHEL8') {
-                            agent {
-                                node {
-                                    label 'yap-rocky-8-v1'
-                                }
-                            }
-                            steps {
-                                unstash 'staging'
-                                container('yap') {
-                                    script {
-                                        if (BRANCH_NAME == 'devel') {
-                                            def timestamp = new Date().format('yyyyMMddHHmmss')
-                                            sh "yap build rocky-8 . -r ${timestamp} -s"
-                                        } else {
-                                            sh 'yap build rocky-8 . -s'
-                                        }
-
-                                    }
-                                }
-                                stash includes: 'artifacts/*el8*.rpm', name: 'artifacts-rhel8'
-                            }
-                            post {
-                                always {
-                                    archiveArtifacts artifacts: "artifacts/*el8*.rpm", fingerprint: true
-                                }
-                            }
-                        }
-
-                        stage('RHEL9') {
-                            agent {
-                                node {
-                                    label 'yap-rocky-9-v1'
-                                }
-                            }
-                            steps {
-                                unstash 'staging'
-                                container('yap') {
-                                    script {
-                                        if (BRANCH_NAME == 'devel') {
-                                            def timestamp = new Date().format('yyyyMMddHHmmss')
-                                            sh "yap build rocky-9 . -r ${timestamp} -s"
-                                        } else {
-                                            sh 'yap build rocky-9 . -s'
-                                        }
-                                    }
-                                }
-                                stash includes: 'artifacts/*el9*.rpm', name: 'artifacts-rhel9'
-                            }
-                            post {
-                                always {
-                                    archiveArtifacts artifacts: "artifacts/*el9*.rpm", fingerprint: true
-                                }
-                            }
-                        }
-                    }
+            steps {
+                echo "Building deb/rpm packages"
+                buildStage()
+            }
         }
 
-        stage('Upload To Playground') {
-            when {
-                anyOf {
-                    branch 'playground/*'
-                    expression { params.PLAYGROUND == true }
-                }
-            }
+        stage('Upload artifacts')
+        {
             steps {
-                unstash 'artifacts-ubuntu-focal'
-                unstash 'artifacts-ubuntu-jammy'
-                unstash 'artifacts-ubuntu-noble'
-                unstash 'artifacts-rhel8'
-                unstash 'artifacts-rhel9'
-
-                script {
-                    def server = Artifactory.server 'zextras-artifactory'
-                    def buildInfo
-                    def uploadSpec
-
-                    buildInfo = Artifactory.newBuildInfo()
-                    uploadSpec = """{
-                        "files": [
-                            {
-                                "pattern": "artifacts/*focal*.deb",
-                                "target": "ubuntu-playground/pool/",
-                                "props": "deb.distribution=focal;deb.component=main;deb.architecture=amd64;vcs.revision=${env.GIT_COMMIT}"
-                            },
-                            {
-                                "pattern": "artifacts/*jammy*.deb",
-                                "target": "ubuntu-playground/pool/",
-                                "props": "deb.distribution=jammy;deb.component=main;deb.architecture=amd64;vcs.revision=${env.GIT_COMMIT}"
-                            },
-                            {
-                                "pattern": "artifacts/*noble*.deb",
-                                "target": "ubuntu-playground/pool/",
-                                "props": "deb.distribution=noble;deb.component=main;deb.architecture=amd64;vcs.revision=${env.GIT_COMMIT}"
-                            },
-                            {
-                                "pattern": "artifacts/(carbonio-mta)-(*).el8.x86_64.rpm",
-                                "target": "centos8-playground/zextras/{1}/{1}-{2}.el8.x86_64.rpm",
-                                "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
-                            },
-                            {
-                                "pattern": "artifacts/(carbonio-mta)-(*).el9.x86_64.rpm",
-                                "target": "rhel9-playground/zextras/{1}/{1}-{2}.el9.x86_64.rpm",
-                                "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
-                            }
-                        ]
-                    }"""
-                    server.upload spec: uploadSpec, buildInfo: buildInfo, failNoOp: false
-                }
-            }
-        }
-        stage('Upload To Devel') {
-            when {
-                branch 'devel'
-            }
-            steps {
-                unstash 'artifacts-ubuntu-focal'
-                unstash 'artifacts-ubuntu-jammy'
-                unstash 'artifacts-ubuntu-noble'
-                unstash 'artifacts-rhel8'
-                unstash 'artifacts-rhel9'
-
-                script {
-                    def server = Artifactory.server 'zextras-artifactory'
-                    def buildInfo
-                    def uploadSpec
-
-                    buildInfo = Artifactory.newBuildInfo()
-                    uploadSpec = """{
-                        "files": [
-                            {
-                                "pattern": "artifacts/*focal*.deb",
-                                "target": "ubuntu-devel/pool/",
-                                "props": "deb.distribution=focal;deb.component=main;deb.architecture=amd64;vcs.revision=${env.GIT_COMMIT}"
-                            },
-                            {
-                                "pattern": "artifacts/*jammy*.deb",
-                                "target": "ubuntu-devel/pool/",
-                                "props": "deb.distribution=jammy;deb.component=main;deb.architecture=amd64;vcs.revision=${env.GIT_COMMIT}"
-                            },
-                            {
-                                "pattern": "artifacts/*noble*.deb",
-                                "target": "ubuntu-devel/pool/",
-                                "props": "deb.distribution=noble;deb.component=main;deb.architecture=amd64;vcs.revision=${env.GIT_COMMIT}"
-                            },
-                            {
-                                "pattern": "artifacts/(carbonio-mta)-(*).el8.x86_64.rpm",
-                                "target": "centos8-devel/zextras/{1}/{1}-{2}.el8.x86_64.rpm",
-                                "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
-                            },
-                            {
-                                "pattern": "artifacts/(carbonio-mta)-(*).el9.x86_64.rpm",
-                                "target": "rhel9-devel/zextras/{1}/{1}-{2}.el9.x86_64.rpm",
-                                "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
-                            }
-                        ]
-                    }"""
-                    server.upload spec: uploadSpec, buildInfo: buildInfo, failNoOp: false
-                }
-            }
-        }
-        stage('Upload & Promotion Config') {
-            when {
-                buildingTag()
-            }
-            steps {
-                unstash 'artifacts-ubuntu-focal'
-                unstash 'artifacts-ubuntu-jammy'
-                unstash 'artifacts-ubuntu-noble'
-                unstash 'artifacts-rhel8'
-                unstash 'artifacts-rhel9'
-
-                script {
-                    def server = Artifactory.server 'zextras-artifactory'
-                    def buildInfo
-                    def uploadSpec
-                    def config
-
-                    //ubuntu
-                    buildInfo = Artifactory.newBuildInfo()
-                    buildInfo.name += "-ubuntu"
-                    uploadSpec= """{
-                        "files": [
-                            {
-                                "pattern": "artifacts/*focal*.deb",
-                                "target": "ubuntu-rc/pool/",
-                                "props": "deb.distribution=focal;deb.component=main;deb.architecture=amd64;vcs.revision=${env.GIT_COMMIT}"
-                            },
-                            {
-                                "pattern": "artifacts/*jammy*.deb",
-                                "target": "ubuntu-rc/pool/",
-                                "props": "deb.distribution=jammy;deb.component=main;deb.architecture=amd64;vcs.revision=${env.GIT_COMMIT}"
-                            },
-                            {
-                                "pattern": "artifacts/*noble*.deb",
-                                "target": "ubuntu-rc/pool/",
-                                "props": "deb.distribution=noble;deb.component=main;deb.architecture=amd64;vcs.revision=${env.GIT_COMMIT}"
-                            }
-                        ]
-                    }"""
-                    server.upload spec: uploadSpec, buildInfo: buildInfo, failNoOp: false
-                    config = [
-                            'buildName'          : buildInfo.name,
-                            'buildNumber'        : buildInfo.number,
-                            'sourceRepo'         : 'ubuntu-rc',
-                            'targetRepo'         : 'ubuntu-release',
-                            'comment'            : 'Do not change anything! Just press the button',
-                            'status'             : 'Released',
-                            'includeDependencies': false,
-                            'copy'               : true,
-                            'failFast'           : true
-                    ]
-                    Artifactory.addInteractivePromotion server: server, promotionConfig: config, displayName: "Ubuntu Promotion to Release"
-                    server.publishBuildInfo buildInfo
-
-                    //rhel8
-                    buildInfo = Artifactory.newBuildInfo()
-                    buildInfo.name += "-centos8"
-                    uploadSpec= """{
-                        "files": [
-                            {
-                                "pattern": "artifacts/(carbonio-mta)-(*).el8.x86_64.rpm",
-                                "target": "centos8-rc/zextras/{1}/{1}-{2}.el8.x86_64.rpm",
-                                "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
-                            }
-                        ]
-                    }"""
-                    server.upload spec: uploadSpec, buildInfo: buildInfo, failNoOp: false
-                    config = [
-                            'buildName'          : buildInfo.name,
-                            'buildNumber'        : buildInfo.number,
-                            'sourceRepo'         : 'centos8-rc',
-                            'targetRepo'         : 'centos8-release',
-                            'comment'            : 'Do not change anything! Just press the button',
-                            'status'             : 'Released',
-                            'includeDependencies': false,
-                            'copy'               : true,
-                            'failFast'           : true
-                    ]
-                    Artifactory.addInteractivePromotion server: server, promotionConfig: config, displayName: "RHEL8 Promotion to Release"
-                    server.publishBuildInfo buildInfo
-
-                    //rhel9
-                    buildInfo = Artifactory.newBuildInfo()
-                    buildInfo.name += "-rhel9"
-                    uploadSpec= """{
-                        "files": [
-                            {
-                                "pattern": "artifacts/x86_64/(carbonio-mta)-(*).el9.x86_64.rpm",
-                                "target": "rhel9-rc/zextras/{1}/{1}-{2}.el9.x86_64.rpm",
-                                "props": "rpm.metadata.arch=x86_64;rpm.metadata.vendor=zextras;vcs.revision=${env.GIT_COMMIT}"
-                            }
-                        ]
-                    }"""
-                    server.upload spec: uploadSpec, buildInfo: buildInfo, failNoOp: false
-                    config = [
-                            'buildName'          : buildInfo.name,
-                            'buildNumber'        : buildInfo.number,
-                            'sourceRepo'         : 'rhel9-rc',
-                            'targetRepo'         : 'rhel9-release',
-                            'comment'            : 'Do not change anything! Just press the button',
-                            'status'             : 'Released',
-                            'includeDependencies': false,
-                            'copy'               : true,
-                            'failFast'           : true
-                    ]
-                    Artifactory.addInteractivePromotion server: server, promotionConfig: config, displayName: "RHEL9 Promotion to Release"
-                    server.publishBuildInfo buildInfo
-                }
+               uploadStage(
+                    packages: yapHelper.getPackageNames()
+                )
             }
         }
     }

--- a/yap.json
+++ b/yap.json
@@ -1,9 +1,9 @@
 {
   "name": "An open-source, community-driven email server",
-  "Description": "MTA",
+  "description": "MTA",
   "buildDir": "/tmp/",
   "output": "artifacts",
-  "Projects": [
+  "projects": [
     {
       "name": "mta"
     }


### PR DESCRIPTION
This PR updates the Jenkins pipeline to use the newly released jenkins-packages-build-library v1.0.1, which introduces major improvements to our build infrastructure:

Key Benefits:

1. reduce duplicated code
2. centralized configuration for supported platforms (ubuntu-jammy, ubuntu-noble etc.)
3. reutilize the playground rt project to test the pipeline release flow

These changes significantly reduce pipeline complexity while making builds more maintainable and reliable across all Zextras repositories.