### PR TITLE
fix(docker): create postfix user/groups for Docker compatibility

### DIFF
--- a/docker/mta/Dockerfile
+++ b/docker/mta/Dockerfile
@@ -7,27 +7,10 @@ ENV LDAP_HOST=openldap
 ENV LDAP_PORT=1389
 EXPOSE 25
 
-RUN apt update && apt install -y gnupg2 ca-certificates && apt clean && \
+RUN apt update && apt install -y gnupg2 ca-certificates systemd-standalone-sysusers && apt clean && \
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A21 && \
 echo deb https://repo.zextras.io/release/ubuntu jammy main > /etc/apt/sources.list.d/zextras.list && \
 apt update && apt install -y carbonio-postfix telnet netcat && apt clean
-
-# carbonio-postfix >= 3.10.5-2 uses systemd-sysusers for user creation,
-# which is not available in Docker base images. Create users manually.
-RUN groupadd -r postdrop 2>/dev/null; \
-    groupadd -r postfix 2>/dev/null; \
-    useradd -r -g postfix -d /opt/zextras/postfix -s /sbin/nologin -c "postfix user" postfix 2>/dev/null; \
-    chgrp postdrop /opt/zextras/common/sbin/postqueue /opt/zextras/common/sbin/postdrop && \
-    chmod u=rwx,g=rsx,o=rx /opt/zextras/common/sbin/postqueue /opt/zextras/common/sbin/postdrop && \
-    chown postfix /opt/zextras/data/postfix && \
-    chown -R postfix:postfix /opt/zextras/data/postfix/spool && \
-    chown root:root /opt/zextras/data/postfix/spool && \
-    chown postfix:root /opt/zextras/data/postfix/spool/pid && \
-    chgrp postdrop /opt/zextras/data/postfix/spool/public && \
-    chgrp postdrop /opt/zextras/data/postfix/spool/maildrop && \
-    chmod 730 /opt/zextras/data/postfix/spool/maildrop && \
-    chown postfix:postdrop /opt/zextras/data/postfix/data && \
-    chmod 755 /opt/zextras/data/postfix/data
 
 COPY docker/mta/conf/ /opt/zextras/conf/
 COPY docker/mta/postfix_header_checks /opt/zextras/conf/postfix_header_checks

--- a/docker/mta/Dockerfile
+++ b/docker/mta/Dockerfile
@@ -7,7 +7,7 @@ ENV LDAP_HOST=openldap
 ENV LDAP_PORT=1389
 EXPOSE 25
 
-RUN apt update && apt install -y gnupg2 ca-certificates systemd-standalone-sysusers && apt clean && \
+RUN apt update && apt install -y gnupg2 ca-certificates systemd-standalone-sysusers systemd-standalone-tmpfiles && apt clean && \
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A21 && \
 echo deb https://repo.zextras.io/release/ubuntu jammy main > /etc/apt/sources.list.d/zextras.list && \
 apt update && apt install -y carbonio-postfix telnet netcat && apt clean

--- a/docker/mta/Dockerfile
+++ b/docker/mta/Dockerfile
@@ -12,6 +12,23 @@ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A
 echo deb https://repo.zextras.io/release/ubuntu jammy main > /etc/apt/sources.list.d/zextras.list && \
 apt update && apt install -y carbonio-postfix telnet netcat && apt clean
 
+# carbonio-postfix >= 3.10.5-2 uses systemd-sysusers for user creation,
+# which is not available in Docker base images. Create users manually.
+RUN groupadd -r postdrop 2>/dev/null; \
+    groupadd -r postfix 2>/dev/null; \
+    useradd -r -g postfix -d /opt/zextras/postfix -s /sbin/nologin -c "postfix user" postfix 2>/dev/null; \
+    chgrp postdrop /opt/zextras/common/sbin/postqueue /opt/zextras/common/sbin/postdrop && \
+    chmod u=rwx,g=rsx,o=rx /opt/zextras/common/sbin/postqueue /opt/zextras/common/sbin/postdrop && \
+    chown postfix /opt/zextras/data/postfix && \
+    chown -R postfix:postfix /opt/zextras/data/postfix/spool && \
+    chown root:root /opt/zextras/data/postfix/spool && \
+    chown postfix:root /opt/zextras/data/postfix/spool/pid && \
+    chgrp postdrop /opt/zextras/data/postfix/spool/public && \
+    chgrp postdrop /opt/zextras/data/postfix/spool/maildrop && \
+    chmod 730 /opt/zextras/data/postfix/spool/maildrop && \
+    chown postfix:postdrop /opt/zextras/data/postfix/data && \
+    chmod 755 /opt/zextras/data/postfix/data
+
 COPY docker/mta/conf/ /opt/zextras/conf/
 COPY docker/mta/postfix_header_checks /opt/zextras/conf/postfix_header_checks
 COPY docker/mta/entrypoint.sh .


### PR DESCRIPTION
## Summary

- `carbonio-postfix >= 3.10.5-2` (from `carbonio-thirds` commit `38b84d2`, CO-2524) migrated user creation from `useradd`/`groupadd` to `systemd-sysusers`
- `systemd-sysusers` is not available in Docker base images (`ubuntu:jammy`), so the `postfix` user is never created
- The postinst silently suppresses the error (`|| :`), so `apt install` succeeds but the user doesn't exist
- At runtime, postfix crashes with: `parameter mail_owner: unknown user name value: postfix`

This broke the `:devel` Docker image on March 13 when it was rebuilt after the 26.3.0 packages were published to the release repo. The `:latest` image (built March 5, before publication) still works but will break on next rebuild.

## Fix

Create the `postfix` user, `postfix` group, and `postdrop` group manually in the Dockerfile, along with the SGID and ownership setup that the old postinst handled.

## Verification

Built and tested locally:
- `postfix check` exits 0 with no warnings
- `postfix` user exists in `/etc/passwd`
- `postdrop`/`postfix` groups exist in `/etc/group`
- SGID on `postqueue`/`postdrop` binaries correct
- Spool directory ownership matches postfix expectations

## Root cause chain

| Repo | Commit | Date | What |
|------|--------|------|------|
| `carbonio-thirds` | `38b84d2` | Jan 15 | Replace `useradd` with `systemd-sysusers` in `carbonio-postfix` PKGBUILD |
| `carbonio-thirds` | `26.3.0` branch | Feb 26 | Build produces `3.10.5-2jammy` package |
| `repo.zextras.io` | — | ~Mar 5-13 | Package published to release apt repo |
| `carbonio-mta` | devel build #102 | Mar 13 | Docker image rebuilds, picks up `-2jammy`, breaks |

🤖 Generated with [Claude Code](https://claude.com/claude-code)