### PR TITLE
chore(deps): update jenkins-lib-common to v2.8.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.8.6',
+    identifier: 'jenkins-lib-common@v2.8.7',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,9 +67,7 @@ pipeline {
                 jfrog 'jfrog-cli'
             }
             steps {
-                uploadStage(
-                    packages: yapHelper.resolvePackageNames()
-                )
+                uploadStage()
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.7.1',
+    identifier: 'jenkins-lib-common@v2.8.6',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
## Description

Upgrade `jenkins-lib-common` from `v2.7.1` to `v2.8.7`.

### Changes applied

- Updated library version reference to `v2.8.7`
- Migrated `uploadStage(packages: ...)` to the new API
  (packages parameter was removed in v2.8.0 — the library now resolves
  package metadata internally from PKGBUILD files)

### Breaking changes in this upgrade

| Version | Change | Action Taken |
|---------|--------|--------------|
| v2.0.0 | Trunk-based branch guards replace `devel*`/`release*` | N/A — already trunk-based |
| v2.8.0 | `uploadStage(packages:)` removed, hard-errors at runtime | Removed `packages: yapHelper.resolvePackageNames()` arg |

### Verification

- [ ] Jenkinsfile syntax is valid
- [x] No `packages:` arg in `uploadStage()` calls
- [x] No orphaned `yapHelper.resolvePackageNames()` calls
- [ ] PR build passes

## Type of change

- [x] Chore / CI (`chore:` / `ci:` / `test:` → no release)

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Branch is rebased on latest default branch with a linear history

## Notes for reviewers

Automated lib-common upgrade. Please verify the Upload stage runs correctly on
the PR build.