### PR TITLE
fix(deps): add explicit service-discover-base dependency

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.7.0',
+    identifier: 'jenkins-lib-common@v2.7.1',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/mta/PKGBUILD
+++ b/mta/PKGBUILD
@@ -27,6 +27,7 @@ depends__apt=(
   "carbonio-postfix"
   "carbonio-spamassassin-rules"
   "sqlite3"
+  "service-discover-base"
 )
 depends__yum=(
   "carbonio-altermime"
@@ -41,6 +42,7 @@ depends__yum=(
   "carbonio-postfix"
   "carbonio-spamassassin-rules"
   "sqlite"
+  "service-discover-base"
 )
 provides=(
   "mail-transport-agent"


### PR DESCRIPTION
## Summary

Fixes CO-3711: sidecar services fail when `/usr/bin/service-discover-wrapper.sh` is missing.

## Root Cause

`service-discover-wrapper.sh` is provided by `service-discover-base`. This package was only a transitive dependency, so if it became stale or mismatched (e.g. installed from a devel repo with a NEVRA no longer available), `dnf reinstall` could not restore the missing file.

## Fix

Add `service-discover-base` as an explicit dependency so the package manager enforces it at install/upgrade time.

## References

- [CO-3711](https://zextras.atlassian.net/browse/CO-3711)

[CO-3711]: https://zextras.atlassian.net/browse/CO-3711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ