### PR TITLE
fix(docker): add missing carbonio runtime deps + postfix users

### DIFF
--- a/docker/mta/Dockerfile
+++ b/docker/mta/Dockerfile
@@ -26,7 +26,9 @@ RUN apt-get update \
       carbonio-postfix:${TARGETARCH} \
       carbonio-icu:${TARGETARCH} \
       carbonio-openssl:${TARGETARCH} \
+      carbonio-openldap:${TARGETARCH} \
       carbonio-cyrus-sasl:${TARGETARCH} \
+      carbonio-mariadb:${TARGETARCH} \
       liblmdb0:${TARGETARCH} \
       libnsl2:${TARGETARCH} \
       libpcre3:${TARGETARCH} \
@@ -38,6 +40,22 @@ RUN apt-get update \
  && mkdir -p /staging/usr/local/lib \
  && find /staging/lib /staging/usr/lib -name '*.so*' -not -path '*/opt/*' \
     -exec cp -P {} /staging/usr/local/lib/ \; 2>/dev/null || true \
+ # Stage /etc additions: postfix/postdrop users + groups (postinst scripts are skipped
+ # by dpkg -x, so synthesize them here — runs on BUILDPLATFORM, no QEMU needed).
+ # UIDs match Debian/Ubuntu carbonio-postfix defaults.
+ && mkdir -p /staging/etc \
+ && cp /etc/passwd /etc/group /etc/shadow /staging/etc/ \
+ && printf 'postfix:x:114:121:Postfix Mail Transport Agent,,,:/var/spool/postfix:/usr/sbin/nologin\n' >> /staging/etc/passwd \
+ && printf 'postfix:x:121:\npostdrop:x:122:\n' >> /staging/etc/group \
+ && printf 'postfix:!:19000:0:99999:7:::\n' >> /staging/etc/shadow \
+ # Chown staged spool/data dirs by numeric UID/GID so ownership survives COPY.
+ # spool/. must be root:root; queue subdirs are postfix:postfix; maildrop/public are postfix:postdrop.
+ # postqueue/postdrop binaries need root:postdrop + setgid (g+s).
+ && chown -R 114:121 /staging/opt/zextras/data/postfix 2>/dev/null || true \
+ && chown 0:0 /staging/opt/zextras/data/postfix/spool 2>/dev/null || true \
+ && chown 114:122 /staging/opt/zextras/data/postfix/spool/maildrop /staging/opt/zextras/data/postfix/spool/public 2>/dev/null || true \
+ && chown 0:122 /staging/opt/zextras/common/sbin/postqueue /staging/opt/zextras/common/sbin/postdrop 2>/dev/null || true \
+ && chmod 2755 /staging/opt/zextras/common/sbin/postqueue /staging/opt/zextras/common/sbin/postdrop 2>/dev/null || true \
  && rm -rf /var/lib/apt/lists/*
 
 # Stage 2: final image — TARGETPLATFORM, zero RUN steps (no QEMU needed).
@@ -53,6 +71,10 @@ EXPOSE 25
 
 COPY --from=postfix-installer /staging/opt /opt
 COPY --from=postfix-installer /staging/usr/local/lib /usr/local/lib/
+# Merged /etc/{passwd,group,shadow} with postfix + postdrop entries added
+COPY --from=postfix-installer /staging/etc/passwd /etc/passwd
+COPY --from=postfix-installer /staging/etc/group /etc/group
+COPY --from=postfix-installer /staging/etc/shadow /etc/shadow
 
 COPY docker/mta/conf/ /opt/zextras/conf/
 COPY docker/mta/postfix_header_checks /opt/zextras/conf/postfix_header_checks


### PR DESCRIPTION
## Problem

Postfix failed to start on the multiarch image with:

```
postconf: error while loading shared libraries: libldap.so.2: cannot open shared object file
postfix: fatal: file /opt/zextras/common/conf/main.cf: parameter mail_owner: unknown user name value: postfix
tail: cannot open '/var/log/postfix.log' for reading: No such file or directory
```

## Root causes

1. `carbonio-postfix` depends on `carbonio-openldap` and `carbonio-mariadb` (Carbonio's own builds under `/opt/zextras/common/lib`), not Ubuntu's `libldap-2.5-0` / `libmariadb3`. These packages were missing from the `apt-get download` list.
2. `dpkg -x` skips postinst scripts, so the `postfix` / `postdrop` users and groups were never created in the final image.

## Fix

- Download `carbonio-openldap` and `carbonio-mariadb` alongside the other carbonio runtime packages.
- Synthesize `/etc/{passwd,group,shadow}` entries for `postfix` (uid 114, gid 121) and `postdrop` (gid 122) in the stage-1 installer (runs on BUILDPLATFORM, no QEMU needed) and COPY them into the final stage.
- Chown staged spool dirs and set `root:postdrop` + setgid (`2755`) on `postqueue` / `postdrop` binaries by numeric UID/GID so ownership survives the COPY into the final stage.

Final stage still has zero RUN steps, preserving the no-QEMU arm64 cross-build path.

## Verification

Built locally for `linux/amd64`:

```
$ podman run --rm carbonio-mta:local-amd64 \
    /opt/zextras/common/sbin/postfix check
# (no warnings)

$ podman run --rm carbonio-mta:local-amd64 \
    /opt/zextras/common/sbin/postfix start
postfix/postlog: starting the Postfix mail system
postfix/master: daemon started -- version 3.10.5
```