### PR TITLE
build: migrate to buildah (FQDN images + jenkins-lib-common@2.10.0)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.8.8',
+    identifier: 'jenkins-lib-common@v2.10.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/docker/mta/Dockerfile
+++ b/docker/mta/Dockerfile
@@ -3,7 +3,7 @@
 # Stage 1: runs natively on BUILDPLATFORM (amd64 CI builder) — no QEMU.
 # Downloads carbonio-postfix + runtime libs for TARGETARCH via apt-get download
 # (no dep resolution, no postinst scripts, no service-discover/carbonio-core).
-FROM --platform=$BUILDPLATFORM ubuntu:jammy AS postfix-installer
+FROM --platform=$BUILDPLATFORM docker.io/library/ubuntu:jammy AS postfix-installer
 
 ARG TARGETARCH
 ARG BUILDARCH=amd64
@@ -59,7 +59,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Stage 2: final image — TARGETPLATFORM, zero RUN steps (no QEMU needed).
-FROM --platform=$TARGETPLATFORM ubuntu:jammy
+FROM --platform=$TARGETPLATFORM docker.io/library/ubuntu:jammy
 USER root
 
 ENV LDAP_ROOT_PASSWORD=qh6hWZvc


### PR DESCRIPTION
## Buildah migration

Replacing `docker buildx` with **buildah**, which requires fully-qualified image references.

### Changes
- **Dockerfiles:** fully-qualify base images (e.g. `alpine:3` -> `docker.io/library/alpine:3`). Multi-stage aliases and already-qualified refs untouched.
- **Jenkinsfile:** bump `jenkins-lib-common` to `@2.10.0`.

> Draft - part of org-wide buildah migration.