### PR TITLE
chore: merge devel into main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@1.7.5',
+    identifier: 'jenkins-lib-common@v2.7.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',
@@ -47,7 +47,8 @@ pipeline {
                     ocLabels: [
                         title: 'Carbonio MTA',
                         descriptionFile: 'docker/mta/description.md',
-                    ]
+                    ],
+                    platforms: ['linux/amd64', 'linux/arm64'] as Set,
                 ])
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.10.0',
+    identifier: 'jenkins-lib-common@v2.10.2',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.10.2',
+    identifier: 'jenkins-lib-common@v2.11.2',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.7.0',
+    identifier: 'jenkins-lib-common@v2.7.1',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.8.8',
+    identifier: 'jenkins-lib-common@v2.10.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.8.7',
+    identifier: 'jenkins-lib-common@v2.8.8',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@1.7.1',
+    identifier: 'jenkins-lib-common@1.7.5',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.7.1',
+    identifier: 'jenkins-lib-common@v2.8.7',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',
@@ -67,9 +67,7 @@ pipeline {
                 jfrog 'jfrog-cli'
             }
             steps {
-                uploadStage(
-                    packages: yapHelper.resolvePackageNames()
-                )
+                uploadStage()
             }
         }
     }

--- a/docker/mta/Dockerfile
+++ b/docker/mta/Dockerfile
@@ -26,7 +26,9 @@ RUN apt-get update \
       carbonio-postfix:${TARGETARCH} \
       carbonio-icu:${TARGETARCH} \
       carbonio-openssl:${TARGETARCH} \
+      carbonio-openldap:${TARGETARCH} \
       carbonio-cyrus-sasl:${TARGETARCH} \
+      carbonio-mariadb:${TARGETARCH} \
       liblmdb0:${TARGETARCH} \
       libnsl2:${TARGETARCH} \
       libpcre3:${TARGETARCH} \
@@ -38,6 +40,22 @@ RUN apt-get update \
  && mkdir -p /staging/usr/local/lib \
  && find /staging/lib /staging/usr/lib -name '*.so*' -not -path '*/opt/*' \
     -exec cp -P {} /staging/usr/local/lib/ \; 2>/dev/null || true \
+ # Stage /etc additions: postfix/postdrop users + groups (postinst scripts are skipped
+ # by dpkg -x, so synthesize them here — runs on BUILDPLATFORM, no QEMU needed).
+ # UIDs match Debian/Ubuntu carbonio-postfix defaults.
+ && mkdir -p /staging/etc \
+ && cp /etc/passwd /etc/group /etc/shadow /staging/etc/ \
+ && printf 'postfix:x:114:121:Postfix Mail Transport Agent,,,:/var/spool/postfix:/usr/sbin/nologin\n' >> /staging/etc/passwd \
+ && printf 'postfix:x:121:\npostdrop:x:122:\n' >> /staging/etc/group \
+ && printf 'postfix:!:19000:0:99999:7:::\n' >> /staging/etc/shadow \
+ # Chown staged spool/data dirs by numeric UID/GID so ownership survives COPY.
+ # spool/. must be root:root; queue subdirs are postfix:postfix; maildrop/public are postfix:postdrop.
+ # postqueue/postdrop binaries need root:postdrop + setgid (g+s).
+ && chown -R 114:121 /staging/opt/zextras/data/postfix 2>/dev/null || true \
+ && chown 0:0 /staging/opt/zextras/data/postfix/spool 2>/dev/null || true \
+ && chown 114:122 /staging/opt/zextras/data/postfix/spool/maildrop /staging/opt/zextras/data/postfix/spool/public 2>/dev/null || true \
+ && chown 0:122 /staging/opt/zextras/common/sbin/postqueue /staging/opt/zextras/common/sbin/postdrop 2>/dev/null || true \
+ && chmod 2755 /staging/opt/zextras/common/sbin/postqueue /staging/opt/zextras/common/sbin/postdrop 2>/dev/null || true \
  && rm -rf /var/lib/apt/lists/*
 
 # Stage 2: final image — TARGETPLATFORM, zero RUN steps (no QEMU needed).
@@ -53,6 +71,10 @@ EXPOSE 25
 
 COPY --from=postfix-installer /staging/opt /opt
 COPY --from=postfix-installer /staging/usr/local/lib /usr/local/lib/
+# Merged /etc/{passwd,group,shadow} with postfix + postdrop entries added
+COPY --from=postfix-installer /staging/etc/passwd /etc/passwd
+COPY --from=postfix-installer /staging/etc/group /etc/group
+COPY --from=postfix-installer /staging/etc/shadow /etc/shadow
 
 COPY docker/mta/conf/ /opt/zextras/conf/
 COPY docker/mta/postfix_header_checks /opt/zextras/conf/postfix_header_checks

--- a/docker/mta/Dockerfile
+++ b/docker/mta/Dockerfile
@@ -3,7 +3,7 @@
 # Stage 1: runs natively on BUILDPLATFORM (amd64 CI builder) — no QEMU.
 # Downloads carbonio-postfix + runtime libs for TARGETARCH via apt-get download
 # (no dep resolution, no postinst scripts, no service-discover/carbonio-core).
-FROM --platform=$BUILDPLATFORM ubuntu:jammy AS postfix-installer
+FROM --platform=$BUILDPLATFORM docker.io/library/ubuntu:jammy AS postfix-installer
 
 ARG TARGETARCH
 ARG BUILDARCH=amd64
@@ -59,7 +59,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Stage 2: final image — TARGETPLATFORM, zero RUN steps (no QEMU needed).
-FROM --platform=$TARGETPLATFORM ubuntu:jammy
+FROM --platform=$TARGETPLATFORM docker.io/library/ubuntu:jammy
 USER root
 
 ENV LDAP_ROOT_PASSWORD=qh6hWZvc

--- a/docker/mta/Dockerfile
+++ b/docker/mta/Dockerfile
@@ -1,19 +1,61 @@
-FROM ubuntu:jammy
+# syntax=docker/dockerfile:1.4
 
+# Stage 1: runs natively on BUILDPLATFORM (amd64 CI builder) — no QEMU.
+# Downloads carbonio-postfix + runtime libs for TARGETARCH via apt-get download
+# (no dep resolution, no postinst scripts, no service-discover/carbonio-core).
+FROM --platform=$BUILDPLATFORM ubuntu:jammy AS postfix-installer
+
+ARG TARGETARCH
+ARG BUILDARCH=amd64
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ # Cross-arch setup when TARGETARCH != BUILDARCH
+ && if [ "${TARGETARCH}" != "${BUILDARCH}" ]; then \
+      dpkg --add-architecture ${TARGETARCH} \
+      && sed -i 's|^deb |deb [arch='"${BUILDARCH}"'] |' /etc/apt/sources.list \
+      && printf 'Types: deb\nURIs: http://ports.ubuntu.com/ubuntu-ports/\nSuites: jammy jammy-updates jammy-security\nComponents: main restricted universe multiverse\nArchitectures: %s\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' "${TARGETARCH}" \
+         > /etc/apt/sources.list.d/ports-${TARGETARCH}.sources; \
+    fi \
+ && printf 'deb [arch=%s trusted=yes] https://repo.area51-zextras.com/devel/ubuntu jammy main\n' "${TARGETARCH}" \
+    > /etc/apt/sources.list.d/zextras.list \
+ && apt-get update \
+ # Download only the packages needed to run postfix — no dep resolution, no carbonio-core
+ && mkdir -p /staging /tmp/debs && cd /tmp/debs \
+ && apt-get download \
+      carbonio-postfix:${TARGETARCH} \
+      carbonio-icu:${TARGETARCH} \
+      carbonio-openssl:${TARGETARCH} \
+      carbonio-cyrus-sasl:${TARGETARCH} \
+      liblmdb0:${TARGETARCH} \
+      libnsl2:${TARGETARCH} \
+      libpcre3:${TARGETARCH} \
+      libsystemd0:${TARGETARCH} \
+ # Extract all debs with dpkg -x — no postinst scripts run
+ && for deb in /tmp/debs/*.deb; do dpkg -x "$deb" /staging; done \
+ && rm -rf /tmp/debs \
+ # Collect arch-specific libs into /staging/usr/local/lib for arch-independent COPY
+ && mkdir -p /staging/usr/local/lib \
+ && find /staging/lib /staging/usr/lib -name '*.so*' -not -path '*/opt/*' \
+    -exec cp -P {} /staging/usr/local/lib/ \; 2>/dev/null || true \
+ && rm -rf /var/lib/apt/lists/*
+
+# Stage 2: final image — TARGETPLATFORM, zero RUN steps (no QEMU needed).
+FROM --platform=$TARGETPLATFORM ubuntu:jammy
 USER root
 
 ENV LDAP_ROOT_PASSWORD=qh6hWZvc
 ENV LDAP_HOST=openldap
 ENV LDAP_PORT=1389
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
 EXPOSE 25
 
-RUN apt update && apt install -y gnupg2 ca-certificates systemd-standalone-sysusers systemd-standalone-tmpfiles && apt clean && \
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 52FD40243E584A21 && \
-echo deb https://repo.zextras.io/release/ubuntu jammy main > /etc/apt/sources.list.d/zextras.list && \
-apt update && apt install -y carbonio-postfix telnet netcat && apt clean
+COPY --from=postfix-installer /staging/opt /opt
+COPY --from=postfix-installer /staging/usr/local/lib /usr/local/lib/
 
 COPY docker/mta/conf/ /opt/zextras/conf/
 COPY docker/mta/postfix_header_checks /opt/zextras/conf/postfix_header_checks
-COPY docker/mta/entrypoint.sh .
+COPY --chmod=755 docker/mta/entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/mta/Dockerfile
+++ b/docker/mta/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1.24
 
 # Stage 1: runs natively on BUILDPLATFORM (amd64 CI builder) — no QEMU.
 # Downloads carbonio-postfix + runtime libs for TARGETARCH via apt-get download

--- a/mta/PKGBUILD
+++ b/mta/PKGBUILD
@@ -13,7 +13,7 @@ license=(
 url="https://github.com/zextras"
 section="mail"
 priority="optional"
-arch=('x86_64')
+arch=('any')
 depends__apt=(
   "carbonio-altermime"
   "carbonio-amavisd"

--- a/mta/PKGBUILD
+++ b/mta/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname="carbonio-mta"
-pkgver="4.2.4"
+pkgver="4.2.5"
 pkgrel="1"
 pkgdesc="An open-source, community-driven email server"
 maintainer="Zextras <packages@zextras.com>"

--- a/mta/PKGBUILD
+++ b/mta/PKGBUILD
@@ -27,6 +27,7 @@ depends__apt=(
   "carbonio-postfix"
   "carbonio-spamassassin-rules"
   "sqlite3"
+  "service-discover-base"
 )
 depends__yum=(
   "carbonio-altermime"
@@ -41,6 +42,7 @@ depends__yum=(
   "carbonio-postfix"
   "carbonio-spamassassin-rules"
   "sqlite"
+  "service-discover-base"
 )
 provides=(
   "mail-transport-agent"


### PR DESCRIPTION
Merges `devel` into `main` to bring main up to date with the latest release (4.2.5).

`devel` is 29 commits ahead of `main`, including versions 4.2.3, 4.2.4, and 4.2.5.