### PR TITLE
ci: update jenkins-lib-common to v2.11.2

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,30 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits",
+      "releaseRules": [
+        {"type": "feat", "release": "minor"},
+        {"type": "fix", "release": "patch"},
+        {"type": "refactor", "release": "patch"},
+        {"type": "docs", "release": "patch"},
+        {"type": "chore", "release": false},
+        {"type": "ci", "release": false},
+        {"type": "test", "release": false},
+        {"breaking": true, "release": "major"}
+      ]
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits"
+    }],
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md"
+    }],
+    ["@semantic-release/git", {
+      "assets": ["CHANGELOG.md"],
+      "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+    }],
+    "@semantic-release/github"
+  ]
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,17 +26,23 @@ pipeline {
         timeout(time: 3, unit: 'HOURS')
     }
 
-
-
     stages {
         stage('Setup') {
             steps {
                 checkout scm
-                script {
-                    gitMetadata()
-                }
+                gitMetadata()
                 stash includes: '**', name: 'staging'
             }
+        }
+
+        stage('Skip CI') {
+            steps {
+                script { semanticRelease.guard() }
+            }
+        }
+
+        stage('Security Scan') {
+            steps { gitleaksStage() }
         }
 
         stage('Publish docker images') {
@@ -68,6 +74,12 @@ pipeline {
             }
             steps {
                 uploadStage()
+            }
+        }
+
+        stage('Semantic Release') {
+            steps {
+                semanticRelease()
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,6 @@ pipeline {
             steps {
                 checkout scm
                 gitMetadata()
-                stash includes: '**', name: 'staging'
             }
         }
 


### PR DESCRIPTION
## Summary
- Bump `jenkins-lib-common` to `v2.11.2`
- Move `gitMetadata()` to top-level step in Setup (out of `script {}` block)
- Add `stage('Skip CI')` with `semanticRelease.guard()` immediately after Setup
- Add `stage('Security Scan')` with `gitleaksStage()` as top-level step
- Add `stage('Semantic Release')` with `semanticRelease()` as top-level step at end of pipeline
- Add `.releaserc.json` with standard Zextras configuration targeting `main`

## Checklist
- [x] Library version bumped to `v2.11.2`
- [x] No `packages:` in `uploadStage` calls
- [x] No `uploadStage.shouldUpload()` when-guard
- [x] No `dt2_semanticRelease()`
- [x] `gitMetadata()` is a top-level step in Setup
- [x] `stage('Skip CI')` with `script { semanticRelease.guard() }` after Setup
- [x] `stage('Security Scan')` with `gitleaksStage()` as top-level step
- [x] `stage('Semantic Release')` with `semanticRelease()` as top-level step (no `script {}`)
- [x] `.releaserc.json` present targeting `main`