### PR TITLE
fix: use tagFormat without v prefix to match existing tags

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,6 @@
 {
   "branches": ["main"],
-  "tagFormat": "v${version}",
+  "tagFormat": "${version}",
   "plugins": [
     ["@semantic-release/commit-analyzer", {
       "preset": "conventionalcommits",


### PR DESCRIPTION
## Problem
`.releaserc.json` had `"tagFormat": "v${version}"` but existing tags use no `v` prefix (e.g. `4.2.5`). semantic-release didn't recognize the last release and created a spurious `v1.0.0` tag.

## Fix
- Change `tagFormat` to `"${version}"` to match existing tag convention
- Delete the spurious `v1.0.0` tag